### PR TITLE
Support "Switch  layout" Windows shortcut 

### DIFF
--- a/BTBatteryWatch.ahk
+++ b/BTBatteryWatch.ahk
@@ -911,10 +911,11 @@ InitialUpdate() {
 }
 
 
+#If (batteryToggleState = "1")
 #Space::
-if (batteryToggleState = "1")
     ShowAllBatteryLevels()
 return
+#If
 
 ; Start the timer immediately when the script starts
 UpdateBatteryIcon()


### PR DESCRIPTION
Hi! 
I'm using Win + Space official shortcut for switching keyboard layout 
<img width="705" height="86" alt="image" src="https://github.com/user-attachments/assets/a001559b-ef25-4dfd-9797-4c8244120a5e" />
Image from [here](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec)

BTBatteryWatch tries to intercept this shortcut despite "Battery monitor Shortkeys" option being turned off 

So I moved option check a little bit higher up. 